### PR TITLE
Check if account is valid before mentioning

### DIFF
--- a/src/pullComments.ts
+++ b/src/pullComments.ts
@@ -73,11 +73,15 @@ export class PullComments {
         const signed = authorMap.getSigned();
         const unsigned = authorMap.getUnsigned();
 
+        let noAccount = authorMap.getNonGithubAccounts();
+
         authorText += `**${signed.length}** out of **${authorMap.count}** committers have signed the CLA.\n`;
         signed.forEach(a => authorText += `:white_check_mark: @${a.name}\n`);
-        unsigned.forEach(a => authorText += `:x: @${a.name}\n`);
+        unsigned.forEach(a => {
+            const hasNoAccount = noAccount.filter(acc => acc.name === a.name).length > 0;
+            authorText += `:x: ${hasNoAccount ? '' : '@'}${a.name}\n`;
+        });
 
-        let noAccount = authorMap.getNonGithubAccounts();
         if (noAccount.length > 0) {
             authorText += "---\n";
             authorText += `GitHub can't find an account for **${noAccount.map(a => a.name).join(', ')}**.\n`


### PR DESCRIPTION
### Problem
The CLA bot will attempt to mention users that contributed to a pull request. Some accounts, however, either no longer exist or can't be found. CLA bot will mention the display name instead, which may unintentionally mention accounts that have not interacted with the repo.

### Solution
This PR adds an additional check for accounts that have not signed the CLA agreement to ensure that a Github account exists. The bot will mention existing Github accounts and will not prepend `@` to users that aren't found.

**Note:** This PR currently assumes that users that signed the CLA have a valid Github account and only checks unsigned accounts as a result.