### PR TITLE
feat: add shared workflow

### DIFF
--- a/.github/workflows/clabot-workflow.yml
+++ b/.github/workflows/clabot-workflow.yml
@@ -54,7 +54,8 @@ jobs:
     steps:
       - name: "Run CLA Bot"
         uses: roblox/cla-signature-bot@v2
-        env: ${{ secrets.GITHUB_TOKEN }}
+        env: 
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           blockchain-storage-flag: ${{ inputs.blockchain-storage-flag }}
           blockchain-webhook-endpoint: ${{ inputs.blockchain-webhook-endpoint }}

--- a/.github/workflows/clabot-workflow.yml
+++ b/.github/workflows/clabot-workflow.yml
@@ -54,6 +54,7 @@ jobs:
     steps:
       - name: "Run CLA Bot"
         uses: roblox/cla-signature-bot@v2
+        env: ${{ github.token }}
         with:
           blockchain-storage-flag: ${{ inputs.blockchain-storage-flag }}
           blockchain-webhook-endpoint: ${{ inputs.blockchain-webhook-endpoint }}

--- a/.github/workflows/clabot-workflow.yml
+++ b/.github/workflows/clabot-workflow.yml
@@ -1,4 +1,5 @@
-name: clabot
+name: CLA Signature Bot
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/clabot-workflow.yml
+++ b/.github/workflows/clabot-workflow.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: "Run CLA Bot"
         uses: roblox/cla-signature-bot@v2
-        env: ${{ github.token }}
+        env: ${{ secrets.GITHUB_TOKEN }}
         with:
           blockchain-storage-flag: ${{ inputs.blockchain-storage-flag }}
           blockchain-webhook-endpoint: ${{ inputs.blockchain-webhook-endpoint }}

--- a/.github/workflows/clabot-workflow.yml
+++ b/.github/workflows/clabot-workflow.yml
@@ -1,5 +1,4 @@
-name: CLA Signature Bot
-
+name: clabot
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/clabot-workflow.yml
+++ b/.github/workflows/clabot-workflow.yml
@@ -3,15 +3,6 @@ name: CLA Signature Bot
 on:
   workflow_call:
     inputs:
-      blockchain-storage-flag:
-        description: "(Optional) Store all the blockchain signatures in the ethirium blockchain as a smart contract."
-        required: false
-        type: boolean
-      blockchain-webhook-endpoint:
-        description: "(Optional) The URL to post the blockchain request to."
-        required: false
-        type: string
-        default: "https://u9afh6n36g.execute-api.eu-central-1.amazonaws.com/dev/webhook"
       branch:
         description: "The branch where the CLAs will be stored."
         required: false
@@ -57,8 +48,6 @@ jobs:
         env: 
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          blockchain-storage-flag: ${{ inputs.blockchain-storage-flag }}
-          blockchain-webhook-endpoint: ${{ inputs.blockchain-webhook-endpoint }}
           branch: ${{ inputs.branch }}
           path-to-signatures: ${{ inputs.path-to-signatures }}
           remote-repo-name: ${{ inputs.remote-repo-name }}

--- a/.github/workflows/clabot-workflow.yml
+++ b/.github/workflows/clabot-workflow.yml
@@ -1,0 +1,68 @@
+name: CLA Signature Bot
+
+on:
+  workflow_call:
+    inputs:
+      blockchain-storage-flag:
+        description: "(Optional) Store all the blockchain signatures in the ethirium blockchain as a smart contract."
+        required: false
+        type: boolean
+      blockchain-webhook-endpoint:
+        description: "(Optional) The URL to post the blockchain request to."
+        required: false
+        type: string
+        default: "https://u9afh6n36g.execute-api.eu-central-1.amazonaws.com/dev/webhook"
+      branch:
+        description: "The branch where the CLAs will be stored."
+        required: false
+        type: string
+        default: "master"
+      path-to-signatures:
+        description: "Give a path for storing CLAs in a json file."
+        required: false
+        type: string
+        default: "signatures/cla.json"
+      remote-repo-name:
+        description: "The name of the remote github repository for storing CLA signatures. Must be owner-name/repo-name format."
+        required: false
+        type: string
+      signature-regex:
+        description: "The regex to locate the signature text. Should be single quoted. Note that comment bodies are toUpperCase'd before matching."
+        required: false
+        type: string
+      signature-text:
+        description: "The text to require as a signature."
+        required: false
+        type: string
+      url-to-cladocument:
+        required: false
+        type: string
+        default: "https://roblox.github.io/cla-bot-store/"
+      use-remote-repo:
+        description: "Whether to use a different repository for storing CLA signatures."
+        required: false
+        type: boolean
+      whitelist:
+        description: "Comma-separated list of users to exclude from CLA requirement. Can use * characters for wildcards."
+        required: false
+        type: string
+
+jobs:
+  clabot:
+    runs-on: ubuntu-latest
+    if: contains(github.event.comment.html_url, '/pull/') || github.event_name != 'issue_comment'
+    steps:
+      - name: "Run CLA Bot"
+        uses: roblox/cla-signature-bot@v2
+        with:
+          blockchain-storage-flag: ${{ inputs.blockchain-storage-flag }}
+          blockchain-webhook-endpoint: ${{ inputs.blockchain-webhook-endpoint }}
+          branch: ${{ inputs.branch }}
+          path-to-signatures: ${{ inputs.path-to-signatures }}
+          remote-repo-name: ${{ inputs.remote-repo-name }}
+          remote-repo-pat: ${{ secrets.CLA_REMOTE_REPO_PAT }}
+          signature-regex: ${{ inputs.signature-regex }}
+          signature-text: ${{ inputs.signature-text }}
+          url-to-cladocument: ${{ inputs.url-to-cladocument }}
+          use-remote-repo: ${{ inputs.use-remote-repo }}
+          whitelist: ${{ inputs.whitelist }}

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -10,4 +10,6 @@ jobs:
     uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@73db6348cf54e038417c862fdb59cac90faea414
     with:
       whitelist: "cliffchapmanrbx"
+      remote-repo-name: "roblox/cla-bot-store"
+      use-remote-repo: true
     secrets: inherit

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -6,7 +6,7 @@ on:
     types: [opened,closed,synchronize]
 
 jobs:
-  call-clabot-workflow:
+  clabot:
     uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@53aadac6d6f5769d33f955c1611b9fc89f8c9a77
     with:
       whitelist: "cliffchapmanrbx"

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -6,17 +6,9 @@ on:
     types: [opened,closed,synchronize]
 
 jobs:
-  clabot:
-    runs-on: ubuntu-latest
+  call-clabot-workflow:
+    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@master
     if: contains(github.event.comment.html_url, '/pull/') || github.event_name != 'issue_comment'
-    steps:
-    - name: "CLA Signature Bot"
-      uses: roblox/cla-signature-bot@v2.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        whitelist: "cliffchapmanrbx"
-        use-remote-repo: true
-        remote-repo-name: "roblox/cla-bot-store"
-        remote-repo-pat: ${{ secrets.CLA_REMOTE_REPO_PAT }}
-        url-to-cladocument: "https://roblox.github.io/cla-bot-store/"
+    with:
+      whitelist: "cliffchapmanrbx"
+    secrets: inherit

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -9,7 +9,7 @@ jobs:
   call-clabot-workflow:
     uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@73db6348cf54e038417c862fdb59cac90faea414
     with:
-      use-remote-repo: true
       whitelist: "cliffchapmanrbx"
+      use-remote-repo: true
       remote-repo-name: "roblox/cla-bot-store"
     secrets: inherit

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -9,7 +9,7 @@ jobs:
   call-clabot-workflow:
     uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@73db6348cf54e038417c862fdb59cac90faea414
     with:
+      use-remote-repo: true
       whitelist: "cliffchapmanrbx"
       remote-repo-name: "roblox/cla-bot-store"
-      use-remote-repo: true
     secrets: inherit

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -6,8 +6,8 @@ on:
     types: [opened,closed,synchronize]
 
 jobs:
-  clabot:
-    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@580f57d62cd843708e8ad0d2b351de4a61d5070c
+  call-clabot-workflow:
+    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@master
     with:
       whitelist: "cliffchapmanrbx"
       use-remote-repo: true

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-clabot-workflow:
-    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@73db6348cf54e038417c862fdb59cac90faea414
+    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@53aadac6d6f5769d33f955c1611b9fc89f8c9a77
     with:
       whitelist: "cliffchapmanrbx"
       use-remote-repo: true

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-clabot-workflow:
-    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@b6dc9b397764e7fce315c1c8e93ccf7a2e8cfa6a
+    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@73db6348cf54e038417c862fdb59cac90faea414
     with:
       whitelist: "cliffchapmanrbx"
     secrets: inherit

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   call-clabot-workflow:
     uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@master
-    if: contains(github.event.comment.html_url, '/pull/') || github.event_name != 'issue_comment'
     with:
       whitelist: "cliffchapmanrbx"
     secrets: inherit

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-clabot-workflow:
-    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@master
+    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@b6dc9b397764e7fce315c1c8e93ccf7a2e8cfa6a
     with:
       whitelist: "cliffchapmanrbx"
     secrets: inherit

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   clabot:
-    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@53aadac6d6f5769d33f955c1611b9fc89f8c9a77
+    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@580f57d62cd843708e8ad0d2b351de4a61d5070c
     with:
       whitelist: "cliffchapmanrbx"
       use-remote-repo: true


### PR DESCRIPTION
This adds a called workflow to allow other GHC repositories to use this instead of having to rewrite the CLA bot workflow from scratch. In addition, this allows for updating the workflow without needing to update the downstream repositories. 

### Notes
* The reusable workflow copies all inputs from the action. They typically aren't used and are defaulted, but lets the workflow be more configurable.
* Required checks should be updated since the reusable workflow changes the check name
* Follow up to this PR requires a batch change to update all repos with dependencies on this workflow.