### PR TITLE
fix: Run test in PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
     needs: build
     # CLA bot comments on pull requests and infers PR number from context.
     # Running on the default branch causes the actiont to fail since it's not running in a PR.
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,6 +42,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: build
+    # CLA bot comments on pull requests and infers PR number from context.
+    # Running on the default branch causes the actiont to fail since it's not running in a PR.
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Updates the `test` step to run in pull requests since the action needs to infer the PR number from context. Running the test step on the default branch will cause it to fail since it won't have a PR number.